### PR TITLE
Added a Tag Selector attribute

### DIFF
--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dcec1a0e459ac74abdc176c2b6ecb29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelector.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelector.cs
@@ -1,0 +1,2 @@
+using UnityEngine;
+public class TagSelectorAttribute : PropertyAttribute{}

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelector.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf6e7e688a4eae34daca31cfb8e35c46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+[CustomPropertyDrawer(typeof(TagSelectorAttribute))]
+public class TagSelectorPropertyDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        if(property.propertyType == SerializedPropertyType.String)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            var tagList = new List<string>(){ "<All Tags>" };
+            tagList.AddRange(UnityEditorInternal.InternalEditorUtility.tags);
+            string propertyString = property.stringValue;
+            int index = -1;
+            if(propertyString == "")
+            {
+                index = 0;
+            }
+            else
+            {
+                for(int i = 1; i < tagList.Count; i++)
+                {
+                    if(tagList[i] == propertyString)
+                    {
+                        index = i;
+                        break;
+                    }
+                }
+            }
+
+            index = EditorGUI.Popup(position, label.text, index, tagList.ToArray());
+            property.stringValue = index >= 1 ? tagList[index] : "";
+
+            EditorGUI.EndProperty();
+        }
+        else
+        {
+            EditorGUI.PropertyField(position, property, label);
+        }
+    }
+}

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
@@ -5,20 +5,20 @@ using System.Collections.Generic;
 [CustomPropertyDrawer(typeof(TagSelectorAttribute))]
 public class TagSelectorPropertyDrawer : PropertyDrawer
 {
-    public int GetElementIndexFromElementList(string find, List<string> list)
-    {
-        int index = 0;
-        for (int i = 1; i < list.Count; i++)
-        {
-            if (list[i] == find)
-            {
-                index = i;
-                break;
-            }
-        }
+    //public int GetElementIndexFromElementList(string find, List<string> list)
+    //{
+    //    int index = 0;
+    //    for (int i = 1; i < list.Count; i++)
+    //    {
+    //        if (list[i] == find)
+    //        {
+    //            index = i;
+    //            break;
+    //        }
+    //    }
 
-        return index;
-    }
+    //    return index;
+    //}
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
         if(property.propertyType == SerializedPropertyType.String)
@@ -26,8 +26,8 @@ public class TagSelectorPropertyDrawer : PropertyDrawer
             EditorGUI.BeginProperty(position, label, property);
             var tagList = new List<string>(){ "<All Tags>" };
             tagList.AddRange(UnityEditorInternal.InternalEditorUtility.tags);
-            
-            int index = GetElementIndexFromElementList(property.stringValue, tagList);
+
+            int index = tagList.FindIndex(a => a.Contains(property.stringValue));
             index = EditorGUI.Popup(position, label.text, index, tagList.ToArray());
             property.stringValue = index >= 1 ? tagList[index] : "";
 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs
@@ -5,32 +5,29 @@ using System.Collections.Generic;
 [CustomPropertyDrawer(typeof(TagSelectorAttribute))]
 public class TagSelectorPropertyDrawer : PropertyDrawer
 {
+    public int GetElementIndexFromElementList(string find, List<string> list)
+    {
+        int index = 0;
+        for (int i = 1; i < list.Count; i++)
+        {
+            if (list[i] == find)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        return index;
+    }
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
         if(property.propertyType == SerializedPropertyType.String)
         {
             EditorGUI.BeginProperty(position, label, property);
-
             var tagList = new List<string>(){ "<All Tags>" };
             tagList.AddRange(UnityEditorInternal.InternalEditorUtility.tags);
-            string propertyString = property.stringValue;
-            int index = -1;
-            if(propertyString == "")
-            {
-                index = 0;
-            }
-            else
-            {
-                for(int i = 1; i < tagList.Count; i++)
-                {
-                    if(tagList[i] == propertyString)
-                    {
-                        index = i;
-                        break;
-                    }
-                }
-            }
-
+            
+            int index = GetElementIndexFromElementList(property.stringValue, tagList);
             index = EditorGUI.Popup(position, label.text, index, tagList.ToArray());
             property.stringValue = index >= 1 ? tagList[index] : "";
 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/TagSelectorDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93204aa767505924093c89bf92f72042
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/TagSelectorTestScript.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/TagSelectorTestScript.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// Usage examples:
+
+// Normal selector to pick from all tags:
+// [TagSelector] public string tag;
+
+// Default tag
+// [TagSelector] public string tag = "Enemy";
+
+// Multiple tags (in array)
+// [TagSelector] public string[];
+
+// Multiple tags with default values
+// [TagSelector] public string[] = { "Untagged", "EditorOnly" };
+
+
+//Picking <All Tags> will return an empty string.
+
+public class TagSelectorTestScript : MonoBehaviour
+{
+    [TagSelector]
+    [SerializeField]
+    string singleTag;
+
+    //Default value
+    [TagSelector]
+    [SerializeField]
+    string singleTagDefaultValue = "Enemy";
+
+    [TagSelector]
+    [SerializeField]
+    string[] arrayTags;
+
+    //Defaults 2 values
+    [TagSelector]
+    [SerializeField]
+    string[] arrayTagsDefaultValue = { "Enemy", "Untagged" };
+}

--- a/CuddleTreeDefenseGame/Assets/Scripts/TagSelectorTestScript.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/TagSelectorTestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb3f4b657c9dddd4cba65892802f2f4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Custom property drawer to access tag enums from a list.

From a script, use [TagSelector] before a string or string array to get a selection list in the inspector.

If used before an array, a list will appear for every array value.

Included a test file (TagSelectorTestScript).
Drag it to any object to test.

Useful if we don't want to add tags using strings, in case we change tag names later.