### PR TITLE
Added a MinMaxRange limiter attribute

### DIFF
--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dcec1a0e459ac74abdc176c2b6ecb29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRange.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRange.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+public class MinMaxRangeAttribute : PropertyAttribute
+{
+    public float minLimit = 0f;
+    public float maxLimit = 100f;
+
+    public MinMaxRangeAttribute(float min, float max)
+    {
+        minLimit = min;
+        maxLimit = max;
+    }
+}

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRange.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03b8d2783755d844dbf73b0b69431404
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRangeDrawer.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRangeDrawer.cs
@@ -1,0 +1,51 @@
+using System;
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(MinMaxRangeAttribute))]
+public class MinMaxRangeDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        var value = attribute as MinMaxRangeAttribute;
+
+        if(property.propertyType == SerializedPropertyType.Vector2)
+        {
+            position = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+
+            float minValue = (float)Math.Round(property.vector2Value.x, 2);
+            float maxValue = (float)Math.Round(property.vector2Value.y, 2);
+            float minLimit = value.minLimit;
+            float maxLimit = value.maxLimit;
+
+            EditorGUI.MinMaxSlider(position, label, ref minValue, ref maxValue, minLimit, maxLimit);
+            position.y += EditorGUIUtility.singleLineHeight;
+
+            var vector2Value = Vector2.zero;
+            vector2Value.x = minValue;
+            vector2Value.y = maxValue;
+
+            var style = new GUIStyle();
+            float indentValue = EditorGUI.indentLevel * 15f;
+            float width = Math.Max(50f, style.CalcSize(new GUIContent(minValue.ToString())).x + 10);
+
+            var leftRect = new Rect(EditorGUIUtility.labelWidth - indentValue + 20f, position.y, width, position.height);
+            vector2Value.x = EditorGUI.FloatField(leftRect, minValue);
+
+            var rightRect = new Rect((position.x - indentValue) + position.width - width, position.y, width, position.height);
+            vector2Value.y = EditorGUI.FloatField(rightRect, maxValue);
+            position.y += EditorGUIUtility.singleLineHeight;
+
+            property.vector2Value = vector2Value;
+        }
+        else
+        {
+            throw new UnityException("Attribute only works for Vector2 properties.");
+        }
+    }
+
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUIUtility.singleLineHeight * 2 + 2f;
+    }
+}

--- a/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRangeDrawer.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/EditorTools/MinMaxRangeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63dfd09818c8a40489820a17f2a8e5b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CuddleTreeDefenseGame/Assets/Scripts/MinMaxRangeTestScript.cs
+++ b/CuddleTreeDefenseGame/Assets/Scripts/MinMaxRangeTestScript.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+//Returns 2 values in a Vector2, a min and a max.
+
+public class MinMaxRangeTestScript : MonoBehaviour
+{
+    //Chose a min value and a max value.
+    //In the inspector cannot pick a lower value than min, or higher than max
+    //Can be negative or positive values
+    //Rounds down to 2 decimals
+
+    //Must return as a vector2 or will return error.
+    [MinMaxRange(-50f, 10f)]
+    [SerializeField]
+    Vector2 testRange;
+    private void Start()
+    {
+        //Return min and max value from Vector2
+        Debug.Log("Min value: " + testRange.x);
+        Debug.Log("Max value: " + testRange.y);
+    }
+
+    //Can use properties to seperate the values:
+    public float MinValue { get => testRange.x; set => testRange.x = value; }
+    public float MaxValue { get => testRange.y; set => testRange.y = value; }
+}

--- a/CuddleTreeDefenseGame/Assets/Scripts/MinMaxRangeTestScript.cs.meta
+++ b/CuddleTreeDefenseGame/Assets/Scripts/MinMaxRangeTestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e5d0f68e4a92204689cb111ff8c9e5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Custom property drawer to draw a min-max slider in the inspector.

Can pick a min and max value by dragging slider or manually input.

Returns a Vector2 with a min and max value.

From a script, use [MinMaxSlider(minValue, maxValue)] before a vector2 to show up in inspector.

Included test file (MinMaxRangeTestScript). Drag to any object to test.